### PR TITLE
Fix method redefinition warnings in threads on Perl >= 5.16

### DIFF
--- a/Changes
+++ b/Changes
@@ -35,6 +35,8 @@ $Revision: 10667 $
   The rt_79190.t could incorrectly fail if your test DSN contained
   the DRIVER attribute.
 
+  Fix method redefinition warnings in threads on Perl >= 5.16
+
   [MISCELLANEOUS]
 
   Added RedHat spec file to examples courtesy of Michiel Beijen.

--- a/ODBC.pm
+++ b/ODBC.pm
@@ -95,6 +95,7 @@ $DBD::ODBC::VERSION = '1.44_3';
         return DBI::parse_trace_flags($class, $flags);
     }
 
+    my $methods_are_installed = 0;
     sub driver{
         return $drh if $drh;
         my($class, $attr) = @_;
@@ -111,13 +112,16 @@ $DBD::ODBC::VERSION = '1.44_3';
             'State' => \$DBD::ODBC::sqlstate,
             'Attribution' => 'DBD::ODBC by Jeff Urlwin, Tim Bunce and Martin J. Evans',
 	    });
-        DBD::ODBC::st->install_method("odbc_lob_read");
-        DBD::ODBC::st->install_method("odbc_rows", { O=>0x00000000 });
-        # don't clear errors - IMA_KEEP_ERR = 0x00000004
-        DBD::ODBC::st->install_method("odbc_getdiagrec", { O=>0x00000004 });
-        DBD::ODBC::db->install_method("odbc_getdiagrec", { O=>0x00000004 });
-        DBD::ODBC::db->install_method("odbc_getdiagfield", { O=>0x00000004 });
-        DBD::ODBC::st->install_method("odbc_getdiagfield", { O=>0x00000004 });
+        if (!$methods_are_installed) {
+            DBD::ODBC::st->install_method("odbc_lob_read");
+            DBD::ODBC::st->install_method("odbc_rows", { O=>0x00000000 });
+            # don't clear errors - IMA_KEEP_ERR = 0x00000004
+            DBD::ODBC::st->install_method("odbc_getdiagrec", { O=>0x00000004 });
+            DBD::ODBC::db->install_method("odbc_getdiagrec", { O=>0x00000004 });
+            DBD::ODBC::db->install_method("odbc_getdiagfield", { O=>0x00000004 });
+            DBD::ODBC::st->install_method("odbc_getdiagfield", { O=>0x00000004 });
+            $methods_are_installed++;
+        }
         return $drh;
     }
 


### PR DESCRIPTION
$drh gets cleared on CLONE, but the driver methods persist.
Due to a bug, this didn't warn until Perl 5.16

```
$ perl -Mthreads -MDBI -MDBD::ODBC -we 'DBI->setup_driver("DBD::ODBC");' \
  -e 'DBD::ODBC->driver; threads->create(sub { DBD::ODBC->driver })->join'
Subroutine DBI::st::odbc_lob_read redefined at ${archlib}/DBI.pm line 1393.
Subroutine DBI::st::odbc_rows redefined at ${archlib}/DBI.pm line 1393.
Subroutine DBI::st::odbc_getdiagrec redefined at ${archlib}/DBI.pm line 1393.
Subroutine DBI::db::odbc_getdiagrec redefined at ${archlib}/DBI.pm line 1393.
Subroutine DBI::db::odbc_getdiagfield redefined at ${archlib}/DBI.pm line 1393.
Subroutine DBI::st::odbc_getdiagfield redefined at ${archlib}/DBI.pm line 1393.
```
