### PR TITLE
UNICODE support via environment variable

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -39,7 +39,7 @@ EOT
 {
     # some useful info when debugging problems
     print "OSNAME: $OSNAME\n";
-    my @envs = qw(LANG ODBCHOME LD_LIBRARY_PATH DBROOT WINDIR II_SYSTEM);
+    my @envs = qw(LANG ODBCHOME LD_LIBRARY_PATH DBROOT WINDIR II_SYSTEM DBD_ODBC_UNICODE);
     foreach (@envs) {
         print "$_: ", ($ENV{$_} ? $ENV{$_} : ''), "\n";
     }
@@ -166,6 +166,8 @@ my $opt_u = undef;              # build unicode version
 my $opt_e = undef;              # easysoft
 my $opt_x = undef;              # prefer unixODBC over iODBC
 my $opt_w = undef;              # enable -Wall (gcc only)
+
+$opt_u = 1 if $ENV{DBD_ODBC_UNICODE};
 
 my @options = ("g!" => \$opt_g,
                "o=s" => \$opt_o,

--- a/ODBC.pm
+++ b/ODBC.pm
@@ -1251,6 +1251,12 @@ platforms the WITH_UNICODE macro is B<not> enabled by default and to enable
 you need to specify the -u argument to Makefile.PL. Please bear in mind
 that some ODBC drivers do not support SQL_Wxxx columns or parameters.
 
+You can also specify that you want UNICODE support by setting the
+C<DBD_ODBC_UNICODE> environment variable prior to install:
+
+  export DBD_ODBC_UNICODE=1
+  cpanm DBD::ODBC
+
 UNICODE support in ODBC Drivers differs considerably. Please read the
 README.unicode file for further details.
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ section in ODBC.pm for usage and distribution rights.
     ODBCHOME  (Unix only) The dir your driver manager is installed in
               or specify this via -o argument to Makefile.PL
 
+    DBD_ODBC_UNICODE Any value here will set the default install to
+                     attempt to turn on UNICODE support.
+
   If you want UNICODE support on non-Windows platforms specify -u
   switch to Makefile.PL. If you don't want UNICODE support on Windows
   specify the -nou switch to Makefile.PL. On non-Windows platforms all


### PR DESCRIPTION
Allow an environment variable to control the unicode flag on install.

The current process is quite cumbersome:
cpanm --look DBD::ODBC
perl Makefile.PL -u
make
make test
make install

With this patch you can serve the same purpose with a simpler
process:
export DBD_ODBC_UNICODE=1
cpanm DBD::ODBC

The -u and -nou flags will still behave as expected.