### PR TITLE
Trivial Markdown syntax fix in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![CPAN version](https://badge.fury.io/pl/DBD-ODBC.svg)](http://badge.fury.io/pl/DBD-ODBC)
 [![CPANTS](http://cpants.cpanauthors.org/dist/DBD-ODBC.png)](http://cpants.cpanauthors.org/dist/DBD-ODBC)
 
-See [LICENSE-AND-COPYRIGHT}(https://metacpan.org/pod/DBD::ODBC#LICENSE-AND-COPYRIGHT)
+See [LICENSE-AND-COPYRIGHT](https://metacpan.org/pod/DBD::ODBC#LICENSE-AND-COPYRIGHT)
 section in ODBC.pm for usage and distribution rights.
 
 # DEPENDENCIES


### PR DESCRIPTION
Fix trivial but annoyingly prominent, as it appears at the very top of
README when viewing it on GitHub, Markdown syntax problem in the licence
and copyright link.