### PR TITLE
Fix internal AutoCommit flag on commit and rollback

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -104,9 +104,10 @@ my %opts =
     # See note below on CONFIGURE. This used to work when we could rely on
     # CONFIGURE being after PREREQ_PM but that is not the case now so the
     # line below does nothing since 6.33 of MakeMaker.
-    PREREQ_PM    => {
+    BUILD_REQUIRES => {
         "Test::Simple" => 0.90, # actually Test::More pkg in T::S dist,
-        "DBI"          => 1.609 },
+        "Test::Output" => 1.031 },
+    PREREQ_PM    => { "DBI" => 1.609 },
     clean        => { FILES => 'ODBC.xsi dbdodbc.h' },
     dist         => {
 	DIST_DEFAULT => 'clean distcheck tardist',

--- a/dbdimp.c
+++ b/dbdimp.c
@@ -1246,6 +1246,7 @@ int dbd_db_commit(SV *dbh, imp_dbh_t *imp_dbh)
       /* reset autocommit */
       rc = SQLSetConnectAttr(
           imp_dbh->hdbc, SQL_ATTR_AUTOCOMMIT, (SQLPOINTER)SQL_AUTOCOMMIT_ON, 0);
+      DBIc_on(imp_dbh,DBIcf_AutoCommit);
       DBIc_off(imp_dbh,DBIcf_BegunWork);
    }
    return 1;
@@ -1267,6 +1268,7 @@ int dbd_db_rollback(SV *dbh, imp_dbh_t *imp_dbh)
       /*  reset autocommit */
       rc = SQLSetConnectAttr(
           imp_dbh->hdbc, SQL_ATTR_AUTOCOMMIT, (SQLPOINTER)SQL_AUTOCOMMIT_ON, 0);
+      DBIc_on(imp_dbh,DBIcf_AutoCommit);
       DBIc_off(imp_dbh,DBIcf_BegunWork);
    }
    return 1;

--- a/t/13autocommit.t
+++ b/t/13autocommit.t
@@ -1,0 +1,98 @@
+#!/usr/bin/perl -w -I./t
+#
+# Check that STORE, commit and rollback sets DBI's internal flags to match connection flags
+#
+use Test::More;
+use Test::Output;
+use strict;
+
+use DBI;
+use_ok('ODBCTEST');
+
+eval "require Test::NoWarnings";
+my $has_test_nowarnings = ($@ ? undef : 1);
+
+
+BEGIN {
+   if (!defined $ENV{DBI_DSN}) {
+      plan skip_all => "DBI_DSN is undefined";
+   }
+    my $dbh = DBI->connect();
+    unless($dbh) {
+        BAIL_OUT("Unable to connect to the database $DBI::errstr\nTests skipped.\n");
+        exit 0;
+    }
+}
+
+END {
+    Test::NoWarnings::had_no_warnings()
+          if ($has_test_nowarnings);
+    done_testing();
+}
+
+{
+    # Test that setting AutoCommit directly sets DBI flags correctly
+    my $dbh = DBI->connect();
+    unless($dbh) {
+        BAIL_OUT("Unable to connect to the database $DBI::errstr\nTests skipped.\n");
+        exit 0;
+    }
+
+    $dbh->{AutoCommit} = 0;
+    ok(!$dbh->{AutoCommit}, 'Connection AutoCommit off');
+    output_unlike(sub { $dbh->dump_handle }, undef, qr/AutoCommit/, 'Internal AutoCommit flag off');
+    # FLAGS 0x100117: COMSET IMPSET Active Warn PrintError PrintWarn
+
+    $dbh->{AutoCommit} = 1;
+    ok($dbh->{AutoCommit}, 'Connection AutoCommit on');
+    output_like(sub { $dbh->dump_handle }, undef, qr/AutoCommit/, 'Internal AutoCommit flag on');
+    # FLAGS 0x100317: COMSET IMPSET Active Warn PrintError PrintWarn AutoCommit
+}
+
+{
+    # Test that commit sets DBI flags correctly
+    my $dbh = DBI->connect();
+    unless($dbh) {
+        BAIL_OUT("Unable to connect to the database $DBI::errstr\nTests skipped.\n");
+        exit 0;
+    }
+
+    $dbh->{AutoCommit} = 1;
+    ok($dbh->FETCH('AutoCommit'), 'Connection AutoCommit on');
+    output_like(sub { $dbh->dump_handle }, undef, qr/AutoCommit/, 'Internal AutoCommit flag on');
+    # FLAGS 0x100317: COMSET IMPSET Active Warn PrintError PrintWarn AutoCommit
+
+    $dbh->begin_work;
+    ok(!$dbh->FETCH('AutoCommit'), 'AutoCommit off');
+    output_unlike(sub { $dbh->dump_handle }, undef, qr/AutoCommit/, 'Internal AutoCommit flag off');
+    # FLAGS 0x104117: COMSET IMPSET Active Warn PrintError PrintWarn BegunWork
+
+    $dbh->commit;
+    ok($dbh->FETCH('AutoCommit'), 'Connection AutoCommit on');
+    output_like(sub { $dbh->dump_handle }, undef, qr/AutoCommit/, 'Internal AutoCommit should be on after commit, no automated rollback should happen');
+    # FLAGS 0x100317: COMSET IMPSET Active Warn PrintError PrintWarn AutoCommit
+
+    # Going out of scope here used to generate a warning like:
+    # DBD::ODBC::db DESTROY failed: [FreeTDS][SQL Server]The ROLLBACK TRANSACTION request has no corresponding BEGIN TRANSACTION. (SQL-25000)
+}
+
+{
+    # Same test for rollback
+    my $dbh = DBI->connect();
+    unless($dbh) {
+        BAIL_OUT("Unable to connect to the database $DBI::errstr\nTests skipped.\n");
+        exit 0;
+    }
+
+    $dbh->{AutoCommit} = 1;
+    ok($dbh->{AutoCommit}, 'Connection AutoCommit on');
+    output_like(sub { $dbh->dump_handle }, undef, qr/AutoCommit/, 'Internal AutoCommit flag on');
+
+    $dbh->begin_work;
+    ok(!$dbh->{AutoCommit}, 'AutoCommit off');
+    output_unlike(sub { $dbh->dump_handle }, undef, qr/AutoCommit/, 'Internal AutoCommit flag off');
+
+    $dbh->rollback;
+    ok($dbh->{AutoCommit}, 'Connection AutoCommit on');
+    output_like(sub { $dbh->dump_handle }, undef, qr/AutoCommit/, 'Internal AutoCommit flag should be on after rollback, so no automated rollback should happen');
+}


### PR DESCRIPTION
This PR fixes a problem that occurs when you begin a transaction and commit it, but don't explicitly disconnect the handle. This results in a `The ROLLBACK TRANSACTION request has no corresponding BEGIN TRANSACTION` error message during destroy.

This happens when AutoCommit is true, and $dbh->begin_work is called.The connection SQL_ATTR_AUTOCOMMIT and DBIcf_AutoCommit will both be false and DBIcf_BegunWork will be true. 

On $dbh->commit, SQL_ATTR_AUTOCOMMIT will be set back to true and DBIcf_BegunWork will be false. However, DBIcf_AutoCommit is still false and out of sync.

During DESTROY, DBI will try to rollback the transaction again since the internal DBI flag DBIcf_AutoCommit is false when it should be true.

To test the internal flags, I used the output from $dbh->dump_handle. I don't think there's any other function that allows you to inspect the internal flags directly, and probably shouldn't be either so people don't start depending on them instead of using the accessors.

I split the commits up in case you'd like to avoid the new dependency on Test::Output or the dependency on $dbh->dump_handle output.